### PR TITLE
mediapipe_simple_subgraph: inject pbtxt instead of binary graph

### DIFF
--- a/mediapipe/framework/tool/mediapipe_graph.bzl
+++ b/mediapipe/framework/tool/mediapipe_graph.bzl
@@ -97,6 +97,10 @@ def data_as_c_string(
         compatible_with = compatible_with,
     )
 
+# [GML] We bypass the binary graph generation, and just inject the text format into the template.
+# [GML] The simple subgraph_template.cc is modified accordingly.
+# [GML] This was done because node_options using external protobufs were not being processed
+# [GML] properly by the existing rule.
 def mediapipe_simple_subgraph(
         name,
         register_as,
@@ -120,16 +124,21 @@ def mediapipe_simple_subgraph(
       **kwargs: Remaining keyword args, forwarded to cc_library.
     """
     graph_base_name = name
-    mediapipe_binary_graph(
-        name = name + "_graph",
-        graph = graph,
-        output_name = graph_base_name + ".binarypb",
-        deps = deps,
-        testonly = testonly,
-    )
+
+    #mediapipe_binary_graph(
+    #    name = name + "_graph",
+    #    graph = graph,
+    #    output_name = graph_base_name + ".binarypb",
+    #    deps = deps,
+    #    testonly = testonly,
+    #    target_compatible_with = target_compatible_with,
+    #)
+
     data_as_c_string(
         name = name + "_inc",
-        srcs = [graph_base_name + ".binarypb"],
+        # [GML] Inject the pbtxt directly.
+        #srcs = [graph_base_name + ".binarypb"],
+        srcs = [graph],
         outs = [graph_base_name + ".inc"],
     )
 

--- a/mediapipe/framework/tool/simple_subgraph_template.cc
+++ b/mediapipe/framework/tool/simple_subgraph_template.cc
@@ -21,7 +21,7 @@
 namespace mediapipe {
 
 // clang-format off
-static const char binary_graph[] =
+static const char pbtxt_graph[] =
 #include "{{SUBGRAPH_INC_FILE_PATH}}"
     ;  // NOLINT(whitespace/semicolon)
 
@@ -30,9 +30,14 @@ class {{SUBGRAPH_CLASS_NAME}} : public Subgraph {
   absl::StatusOr<CalculatorGraphConfig> GetConfig(
         const SubgraphOptions& /*options*/) {
     CalculatorGraphConfig config;
+
+    // [GML] Modified to accept the pbtxt instead of a binary format.
+    bool ok = google::protobuf::TextFormat::ParseFromString(pbtxt_graph, &config);
+    // bool ok = config.ParseFromArray(binary_graph, sizeof(binary_graph) - 1);
+
     // Note: this is a binary protobuf serialization, and may include NUL
     // bytes. The trailing NUL added to the string literal should be excluded.
-    if (config.ParseFromArray(binary_graph, sizeof(binary_graph) - 1)) {
+    if (ok) {
       return config;
     } else {
       return absl::InternalError("Could not parse subgraph.");


### PR DESCRIPTION
This PR changes mediapipe_simple_subgraph because the original version was not working with node_options that referenced external protos.

Signed-off-by: Omid Azizi <oazizi@gimletlabs.ai>
