### PR TITLE
Remove unused rdeps

### DIFF
--- a/mediapipe/calculators/tensor/BUILD
+++ b/mediapipe/calculators/tensor/BUILD
@@ -614,7 +614,6 @@ cc_library(
         ":inference_calculator_interface",
     ] + select({
         "//conditions:default": [":inference_calculator_gl_if_compute_shader_available"],
-        ":platform_ios_with_gpu": [":inference_calculator_metal"],
     }),
     alwayslink = 1,
 )
@@ -683,15 +682,6 @@ cc_library(
     name = "tensor_converter_calculator_gpu_deps",
     visibility = ["//visibility:private"],
     deps = select({
-        "//mediapipe:android": [
-            "//mediapipe/gpu:gl_calculator_helper",
-            "//mediapipe/gpu:gpu_buffer",
-        ],
-        "//mediapipe:ios": [
-            "//mediapipe/gpu:MPPMetalHelper",
-            "//mediapipe/gpu:MPPMetalUtil",
-            "//mediapipe/objc:mediapipe_framework_ios",
-        ],
         "//mediapipe:macos": [],
         "//conditions:default": [
             "//mediapipe/gpu:gl_calculator_helper",
@@ -777,10 +767,6 @@ cc_library(
     name = "tensors_to_detections_calculator_gpu_deps",
     visibility = ["//visibility:private"],
     deps = select({
-        "//mediapipe:ios": [
-            "//mediapipe/gpu:MPPMetalHelper",
-            "//mediapipe/gpu:MPPMetalUtil",
-        ],
         "//mediapipe:macos": [],
         "//conditions:default": [
             "//mediapipe/gpu:gl_calculator_helper",
@@ -1386,11 +1372,6 @@ cc_library(
         ],
     }) + selects.with_or({
         ":gpu_inference_disabled": [],
-        "//mediapipe:ios": [
-            "//mediapipe/gpu:MPPMetalUtil",
-            "//mediapipe/gpu:MPPMetalHelper",
-            "//third_party/apple_frameworks:MetalKit",
-        ],
         "//conditions:default": [
             "@org_tensorflow//tensorflow/lite/delegates/gpu:gl_delegate",
             "@org_tensorflow//tensorflow/lite/delegates/gpu/gl:gl_program",

--- a/mediapipe/calculators/tflite/BUILD
+++ b/mediapipe/calculators/tflite/BUILD
@@ -211,18 +211,6 @@ cc_library(
         "@org_tensorflow//tensorflow/lite/kernels:builtin_ops",
     ] + selects.with_or({
         ":gpu_inference_disabled": [],
-        "//mediapipe:ios": [
-            "//mediapipe/gpu:MPPMetalHelper",
-            "//mediapipe/gpu:MPPMetalUtil",
-            "//mediapipe/gpu:gpu_buffer",
-            "//mediapipe/objc:mediapipe_framework_ios",
-            "@org_tensorflow//tensorflow/lite/delegates/gpu/common:shape",
-            "@org_tensorflow//tensorflow/lite/delegates/gpu/metal:buffer_convert",
-            "@org_tensorflow//tensorflow/lite/delegates/gpu:metal_delegate",
-            "@org_tensorflow//tensorflow/lite/delegates/gpu:metal_delegate_internal",
-            "//third_party/apple_frameworks:MetalKit",
-            "//third_party/apple_frameworks:CoreVideo",
-        ],
         "//conditions:default": [
             "//mediapipe/util/tflite:tflite_gpu_runner",
             "//mediapipe/gpu:gl_calculator_helper",
@@ -285,14 +273,6 @@ cc_library(
         "@org_tensorflow//tensorflow/lite/kernels:builtin_ops",
     ] + selects.with_or({
         ":gpu_inference_disabled": [],
-        "//mediapipe:ios": [
-            "//mediapipe/gpu:MPPMetalUtil",
-            "//mediapipe/gpu:MPPMetalHelper",
-            "//mediapipe/objc:mediapipe_framework_ios",
-            "@org_tensorflow//tensorflow/lite/delegates/gpu:metal_delegate",
-            "//third_party/apple_frameworks:MetalKit",
-            "//third_party/apple_frameworks:CoreVideo",
-        ],
         "//conditions:default": [
             "//mediapipe/gpu:gl_calculator_helper",
             "@org_tensorflow//tensorflow/lite/delegates/gpu:gl_delegate",
@@ -405,15 +385,6 @@ cc_library(
         "@org_tensorflow//tensorflow/lite:framework",
     ] + selects.with_or({
         ":gpu_inference_disabled": [],
-        "//mediapipe:ios": [
-            "//mediapipe/gpu:MPPMetalUtil",
-            "//mediapipe/gpu:gpu_buffer",
-            "//mediapipe/gpu:MPPMetalHelper",
-            "//mediapipe/objc:mediapipe_framework_ios",
-            "@org_tensorflow//tensorflow/lite/delegates/gpu:metal_delegate",
-            "//third_party/apple_frameworks:MetalKit",
-            "//third_party/apple_frameworks:CoreVideo",
-        ],
         "//conditions:default": [
             "//mediapipe/gpu:gl_calculator_helper",
             "@org_tensorflow//tensorflow/lite/delegates/gpu:gl_delegate",

--- a/mediapipe/gpu/BUILD
+++ b/mediapipe/gpu/BUILD
@@ -648,10 +648,6 @@ cc_library(
         "@com_google_absl//absl/log:absl_check",
     ] + select({
         "//conditions:default": [],
-        "//mediapipe:apple": [
-            ":cv_texture_cache_manager",
-            ":metal_shared_resources",
-        ],
     }),
 )
 

--- a/mediapipe/java/com/google/mediapipe/mediapipe_aar.bzl
+++ b/mediapipe/java/com/google/mediapipe/mediapipe_aar.bzl
@@ -196,10 +196,6 @@ def _mediapipe_jni(name, gen_libmediapipe, calculators = []):
     native.cc_library(
         name = name + "_opencv_cc_lib",
         srcs = select({
-            "//mediapipe:android_arm64": ["@android_opencv//:libopencv_java3_so_arm64-v8a"],
-            "//mediapipe:android_arm": ["@android_opencv//:libopencv_java3_so_armeabi-v7a"],
-            "//mediapipe:android_x86": ["@android_opencv//:libopencv_java3_so_x86"],
-            "//mediapipe:android_x86_64": ["@android_opencv//:libopencv_java3_so_x86_64"],
             "//conditions:default": [],
         }),
         alwayslink = 1,

--- a/mediapipe/tasks/ios/BUILD
+++ b/mediapipe/tasks/ios/BUILD
@@ -221,10 +221,6 @@ apple_static_library(
     deps = CALCULATORS_AND_GRAPHS + [
         "@org_tensorflow//third_party/icu/data:conversion_data",
     ] + select({
-        "//third_party:opencv_ios_sim_arm64_source_build": ["@ios_opencv_source//:opencv_xcframework"],
-        "//third_party:opencv_ios_arm64_source_build": ["@ios_opencv_source//:opencv_xcframework"],
-        "//third_party:opencv_ios_x86_64_source_build": ["@ios_opencv_source//:opencv_xcframework"],
-        "//third_party:opencv_ios_sim_fat_source_build": ["@ios_opencv_source//:opencv_xcframework"],
         "//conditions:default": ["@ios_opencv//:OpencvFramework"],
     }),
 )

--- a/mediapipe/tasks/java/com/google/mediapipe/tasks/mediapipe_tasks_aar.bzl
+++ b/mediapipe/tasks/java/com/google/mediapipe/tasks/mediapipe_tasks_aar.bzl
@@ -368,10 +368,6 @@ def _mediapipe_tasks_aar(name, srcs, manifest, java_proto_lite_targets, native_l
     native.cc_library(
         name = name + "_jni_opencv_cc_lib",
         srcs = select({
-            "//mediapipe:android_arm64": ["@android_opencv//:libopencv_java3_so_arm64-v8a"],
-            "//mediapipe:android_arm": ["@android_opencv//:libopencv_java3_so_armeabi-v7a"],
-            "//mediapipe:android_x86": ["@android_opencv//:libopencv_java3_so_x86"],
-            "//mediapipe:android_x86_64": ["@android_opencv//:libopencv_java3_so_x86_64"],
             "//conditions:default": [],
         }),
         alwayslink = 1,

--- a/mediapipe/util/BUILD
+++ b/mediapipe/util/BUILD
@@ -91,9 +91,6 @@ cc_library(
         "@com_google_absl//absl/strings",
     ] + select({
         "//conditions:default": [],
-        "//mediapipe:android": [
-            "@androidndk//:cpufeatures",
-        ],
     }),
 )
 

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -26,21 +26,6 @@ cc_library(
     name = "glog",
     visibility = ["//visibility:public"],
     deps = select({
-        "//mediapipe:android_x86": [
-            "@com_github_glog_glog_no_gflags//:glog",
-        ],
-        "//mediapipe:android_x86_64": [
-            "@com_github_glog_glog_no_gflags//:glog",
-        ],
-        "//mediapipe:android_arm": [
-            "@com_github_glog_glog_no_gflags//:glog",
-        ],
-        "//mediapipe:android_arm64": [
-            "@com_github_glog_glog_no_gflags//:glog",
-        ],
-        "//mediapipe:ios": [
-            "@com_github_glog_glog_no_gflags//:glog",
-        ],
         "//mediapipe:macos": [
             "@com_github_glog_glog//:glog",
         ],
@@ -108,11 +93,7 @@ config_setting(
 alias(
     name = "opencv",
     actual = select({
-        ":opencv_source_build": "@com_github_opencv_opencv//:opencv",
-        ":opencv_ios_sim_arm64_source_build": "@ios_opencv_source//:opencv",
-        ":opencv_ios_arm64_source_build": "@ios_opencv_source//:opencv",
-        ":opencv_ios_x86_64_source_build": "@ios_opencv_source//:opencv",
-        "//conditions:default": ":opencv_binary",
+        "//conditions:default": "@com_github_opencv_opencv//:opencv",
     }),
     visibility = ["//visibility:public"],
 )
@@ -132,13 +113,6 @@ bzl_library(
 alias(
     name = "opencv_binary",
     actual = select({
-        "//mediapipe:android_x86": "@android_opencv//:libopencv_x86",
-        "//mediapipe:android_x86_64": "@android_opencv//:libopencv_x86_64",
-        "//mediapipe:android_arm": "@android_opencv//:libopencv_armeabi-v7a",
-        "//mediapipe:android_arm64": "@android_opencv//:libopencv_arm64-v8a",
-        "//mediapipe:ios": "@ios_opencv//:opencv",
-        "//mediapipe:macos": "@macos_opencv//:opencv",
-        "//mediapipe:windows": "@windows_opencv//:opencv",
         "//conditions:default": "@linux_opencv//:opencv",
     }),
 )


### PR DESCRIPTION
These deps show up in rdeps which causes skaffold builds of gem to fail.
Since we don't provide these anyway, remove them.