### PR TITLE
Fix enum prefixes for tracking enums

### DIFF
--- a/mediapipe/calculators/video/motion_analysis_calculator.cc
+++ b/mediapipe/calculators/video/motion_analysis_calculator.cc
@@ -934,7 +934,7 @@ void MotionAnalysisCalculator::AppendCameraMotionsFromHomographies(
   *identity.mutable_translation() = TranslationModel();
   *identity.mutable_linear_similarity() = LinearSimilarityModel();
   *identity.mutable_homography() = Homography();
-  identity.set_type(CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_VALID);
+  identity.set_type(CameraMotion::CAMERA_MOTION_TYPE_VALID);
   identity.set_match_frame(0);
 
   RegionFlowFeatureList empty_list;

--- a/mediapipe/calculators/video/motion_analysis_calculator.cc
+++ b/mediapipe/calculators/video/motion_analysis_calculator.cc
@@ -725,17 +725,17 @@ absl::Status MotionAnalysisCalculator::InitOnProcess(
     switch (video_stream->Get<ImageFrame>().Format()) {
       case ImageFormat::FORMAT_GRAY8:
         image_format = image_format2 =
-            RegionFlowComputationOptions::REGION_FLOW_FORMAT_GRAYSCALE;
+            RegionFlowComputationOptions::IMAGE_FORMAT_GRAYSCALE;
         break;
 
       case ImageFormat::FORMAT_SRGB:
-        image_format = RegionFlowComputationOptions::REGION_FLOW_FORMAT_RGB;
-        image_format2 = RegionFlowComputationOptions::REGION_FLOW_FORMAT_BGR;
+        image_format = RegionFlowComputationOptions::IMAGE_FORMAT_RGB;
+        image_format2 = RegionFlowComputationOptions::IMAGE_FORMAT_BGR;
         break;
 
       case ImageFormat::FORMAT_SRGBA:
-        image_format = RegionFlowComputationOptions::REGION_FLOW_FORMAT_RGBA;
-        image_format2 = RegionFlowComputationOptions::REGION_FLOW_FORMAT_BGRA;
+        image_format = RegionFlowComputationOptions::IMAGE_FORMAT_RGBA;
+        image_format2 = RegionFlowComputationOptions::IMAGE_FORMAT_BGRA;
         break;
 
       default:
@@ -752,7 +752,7 @@ absl::Status MotionAnalysisCalculator::InitOnProcess(
     // already downsampled frames but the resulting CameraMotion should
     // be computed on higher resolution as specifed by the downsample scale.
     if (region_options->downsample_mode() ==
-        RegionFlowComputationOptions::REGION_FLOW_DOWNSAMPLE_TO_INPUT_SIZE) {
+        RegionFlowComputationOptions::DOWNSAMPLE_MODE_TO_INPUT_SIZE) {
       const float scale = region_options->downsample_factor();
       frame_width_ = static_cast<int>(std::round(frame_width_ * scale));
       frame_height_ = static_cast<int>(std::round(frame_height_ * scale));

--- a/mediapipe/framework/tool/simple_subgraph_template.cc
+++ b/mediapipe/framework/tool/simple_subgraph_template.cc
@@ -40,7 +40,7 @@ class {{SUBGRAPH_CLASS_NAME}} : public Subgraph {
     if (ok) {
       return config;
     } else {
-      return absl::InternalError("Could not parse subgraph.");
+      return absl::InternalError(absl::Substitute("Could not parse subgraph $0.", "{{SUBGRAPH_CLASS_NAME}}"));
     }
   }
 };

--- a/mediapipe/util/tracking/camera_motion.cc
+++ b/mediapipe/util/tracking/camera_motion.cc
@@ -112,7 +112,7 @@ CameraMotion ComposeCameraMotion(const CameraMotion& lhs,
           << "Mixture homographies are not closed under composition, "
           << "Only rhs mixtures composed with lhs homographies "
           << "are supported.";
-    } else if (lhs.type() <= CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE_SIM) {
+    } else if (lhs.type() <= CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE_SIM) {
       // We only composit base model when stability is sufficient.
       *result.mutable_mixture_homography() =
           MixtureHomographyAdapter::ComposeLeft(rhs.mixture_homography(),
@@ -267,27 +267,27 @@ void InitCameraMotionFromFeatureList(const RegionFlowFeatureList& feature_list,
 
 std::string CameraMotionFlagToString(const CameraMotion& camera_motion) {
   std::string text;
-  if (camera_motion.flags() & CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SHOT_BOUNDARY) {
+  if (camera_motion.flags() & CameraMotion::CAMERA_MOTION_FLAG_SHOT_BOUNDARY) {
     text += "SHOT_BOUNDARY|";
   }
 
-  if (camera_motion.flags() & CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_BLURRY_FRAME) {
+  if (camera_motion.flags() & CameraMotion::CAMERA_MOTION_FLAG_BLURRY_FRAME) {
     text += absl::StrFormat("BLURRY_FRAME %.2f|", camera_motion.bluriness());
   }
 
-  if (camera_motion.flags() & CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_MAJOR_OVERLAY) {
+  if (camera_motion.flags() & CameraMotion::CAMERA_MOTION_FLAG_MAJOR_OVERLAY) {
     text += "MAJOR_OVERLAY|";
   }
 
-  if (camera_motion.flags() & CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SHARP_FRAME) {
+  if (camera_motion.flags() & CameraMotion::CAMERA_MOTION_FLAG_SHARP_FRAME) {
     text += "SHARP_FRAME|";
   }
 
-  if (camera_motion.flags() & CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SHOT_FADE) {
+  if (camera_motion.flags() & CameraMotion::CAMERA_MOTION_FLAG_SHOT_FADE) {
     text += "SHOT_FADE|";
   }
 
-  if (camera_motion.flags() & CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_DUPLICATED) {
+  if (camera_motion.flags() & CameraMotion::CAMERA_MOTION_FLAG_DUPLICATED) {
     text += "DUPLICATED|";
   }
   return text;
@@ -295,15 +295,15 @@ std::string CameraMotionFlagToString(const CameraMotion& camera_motion) {
 
 std::string CameraMotionTypeToString(const CameraMotion& motion) {
   switch (motion.type()) {
-    case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_VALID:
+    case CameraMotion::CAMERA_MOTION_TYPE_VALID:
       return "VALID";
-    case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE_HOMOG:
+    case CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE_HOMOG:
       return "UNSTABLE_HOMOG";
-    case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE_SIM:
+    case CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE_SIM:
       return "UNSTABLE_SIM";
-    case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE:
+    case CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE:
       return "UNSTABLE";
-    case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_INVALID:
+    case CameraMotion::CAMERA_MOTION_TYPE_INVALID:
       return "INVALID";
   }
 
@@ -355,20 +355,20 @@ CameraMotion FirstCameraMotionForLooping(
     }
 
     switch (motion.type()) {
-      case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_INVALID:
+      case CameraMotion::CAMERA_MOTION_TYPE_INVALID:
         has_translation = false;
         has_similarity = false;
         has_homography = false;
         break;
-      case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE:
+      case CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE:
         has_similarity = false;
         has_homography = false;
         break;
-      case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE_SIM:
+      case CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE_SIM:
         has_homography = false;
         break;
-      case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_VALID:
-      case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE_HOMOG:
+      case CameraMotion::CAMERA_MOTION_TYPE_VALID:
+      case CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE_HOMOG:
         break;
       default:
         ABSL_LOG(FATAL) << "Unknown CameraMotion::type.";

--- a/mediapipe/util/tracking/camera_motion.h
+++ b/mediapipe/util/tracking/camera_motion.h
@@ -148,25 +148,25 @@ template <class Model>
 Model UnstableCameraMotionToModel(const CameraMotion& camera_motion,
                                   CameraMotion::Type unstable_type) {
   switch (unstable_type) {
-    case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_INVALID:
+    case CameraMotion::CAMERA_MOTION_TYPE_INVALID:
       return Model();  // Identity.
 
-    case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE: {
+    case CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE: {
       return ModelAdapter<Model>::Embed(
           CameraMotionToModel<TranslationModel>(camera_motion));
     }
 
-    case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE_SIM: {
+    case CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE_SIM: {
       return ModelAdapter<Model>::Embed(
           CameraMotionToModel<LinearSimilarityModel>(camera_motion));
     }
 
-    case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE_HOMOG: {
+    case CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE_HOMOG: {
       return ModelAdapter<Model>::Embed(
           CameraMotionToModel<Homography>(camera_motion));
     }
 
-    case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_VALID:
+    case CameraMotion::CAMERA_MOTION_TYPE_VALID:
       ABSL_LOG(FATAL) << "Specify a type != VALID";
       return Model();
   }
@@ -178,7 +178,7 @@ inline TranslationModel ProjectToTypeModel(const TranslationModel& model,
                                            float frame_height,
                                            CameraMotion::Type type) {
   switch (type) {
-    case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_INVALID:
+    case CameraMotion::CAMERA_MOTION_TYPE_INVALID:
       return TranslationModel();  // Identity.
     default:
       return model;
@@ -190,10 +190,10 @@ inline LinearSimilarityModel ProjectToTypeModel(
     const LinearSimilarityModel& model, float frame_width, float frame_height,
     CameraMotion::Type type) {
   switch (type) {
-    case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_INVALID:
+    case CameraMotion::CAMERA_MOTION_TYPE_INVALID:
       return LinearSimilarityModel();  // Identity.
 
-    case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE:
+    case CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE:
       return LinearSimilarityAdapter::Embed(
           TranslationAdapter::ProjectFrom(model, frame_width, frame_height));
 
@@ -206,14 +206,14 @@ template <class Model>
 Model ProjectToTypeModel(const Model& model, float frame_width,
                          float frame_height, CameraMotion::Type type) {
   switch (type) {
-    case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_INVALID:
+    case CameraMotion::CAMERA_MOTION_TYPE_INVALID:
       return Model();  // Identity.
 
-    case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE:
+    case CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE:
       return ModelAdapter<Model>::Embed(
           TranslationAdapter::ProjectFrom(model, frame_width, frame_height));
 
-    case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE_SIM:
+    case CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE_SIM:
       return ModelAdapter<Model>::Embed(LinearSimilarityAdapter::ProjectFrom(
           model, frame_width, frame_height));
 
@@ -255,7 +255,7 @@ void DownsampleMotionModels(
     const int last_idx =
         std::min<int>(model_idx + downsample_scale, num_models) - 1;
 
-    CameraMotion::Type sampled_type = CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_VALID;
+    CameraMotion::Type sampled_type = CameraMotion::CAMERA_MOTION_TYPE_VALID;
     if (model_type) {
       // Get least stable model within downsample window (max operation).
       for (int i = model_idx; i <= last_idx; ++i) {

--- a/mediapipe/util/tracking/flow_packager.cc
+++ b/mediapipe/util/tracking/flow_packager.cc
@@ -161,7 +161,7 @@ void FlowPackager::PackFlow(const RegionFlowFeatureList& feature_list,
   int flags = 0;
 
   if (camera_motion == nullptr ||
-      camera_motion->type() > CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE_SIM) {
+      camera_motion->type() > CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE_SIM) {
     flags |= TrackingData::TRACKING_FLAG_BACKGROUND_UNSTABLE;
   } else {
     Homography transform;

--- a/mediapipe/util/tracking/motion_analysis.cc
+++ b/mediapipe/util/tracking/motion_analysis.cc
@@ -93,7 +93,7 @@ MotionAnalysis::MotionAnalysis(const MotionAnalysisOptions& options,
       use_spatial_bias;
 
   if (compute_feature_descriptors_) {
-    ABSL_CHECK_EQ(RegionFlowComputationOptions::REGION_FLOW_FORMAT_RGB,
+    ABSL_CHECK_EQ(RegionFlowComputationOptions::IMAGE_FORMAT_RGB,
                   options_.flow_options().image_format())
         << "Feature descriptors only support RGB currently.";
     prev_frame_.reset(new cv::Mat(frame_height_, frame_width_, CV_8UC3));
@@ -139,7 +139,7 @@ void MotionAnalysis::InitPolicyOptions() {
       tracking_options->set_internal_tracking_direction(
           TrackingOptions::FLOW_DIRECTION_FORWARD);
       tracking_options->set_tracking_policy(
-          TrackingOptions::FLOW_DIRECTION_POLICY_LONG_TRACKS);
+          TrackingOptions::TRACKING_POLICY_LONG_TRACKS);
 
       feature_bias_options->set_use_spatial_bias(false);
       feature_bias_options->set_seed_priors_from_bias(true);
@@ -153,7 +153,7 @@ void MotionAnalysis::InitPolicyOptions() {
 
       // Speed.
       flow_options->set_downsample_mode(
-          RegionFlowComputationOptions::REGION_FLOW_DOWNSAMPLE_BY_SCHEDULE);
+          RegionFlowComputationOptions::DOWNSAMPLE_MODE_BY_SCHEDULE);
 
       motion_options->set_estimation_policy(
           MotionEstimationOptions::TEMPORAL_LONG_FEATURE_BIAS);
@@ -173,7 +173,7 @@ void MotionAnalysis::InitPolicyOptions() {
       tracking_options->set_internal_tracking_direction(
           TrackingOptions::FLOW_DIRECTION_FORWARD);
       tracking_options->set_tracking_policy(
-          TrackingOptions::FLOW_DIRECTION_POLICY_LONG_TRACKS);
+          TrackingOptions::TRACKING_POLICY_LONG_TRACKS);
 
       motion_options->set_estimation_policy(
           MotionEstimationOptions::TEMPORAL_LONG_FEATURE_BIAS);
@@ -197,7 +197,7 @@ void MotionAnalysis::InitPolicyOptions() {
       tracking_options->set_max_features(500);
 
       flow_options->set_downsample_mode(
-          RegionFlowComputationOptions::REGION_FLOW_DOWNSAMPLE_TO_MIN_SIZE);
+          RegionFlowComputationOptions::DOWNSAMPLE_MODE_TO_MIN_SIZE);
       flow_options->set_round_downsample_factor(true);
       flow_options->set_downsampling_size(256);
       flow_options->set_pre_blur_sigma(0);
@@ -223,7 +223,7 @@ void MotionAnalysis::InitPolicyOptions() {
       tracking_options->set_internal_tracking_direction(
           TrackingOptions::FLOW_DIRECTION_FORWARD);
       tracking_options->set_tracking_policy(
-          TrackingOptions::FLOW_DIRECTION_POLICY_LONG_TRACKS);
+          TrackingOptions::TRACKING_POLICY_LONG_TRACKS);
 
       motion_options->set_estimation_policy(
           MotionEstimationOptions::TEMPORAL_IRLS_MASK);
@@ -269,7 +269,7 @@ void MotionAnalysis::InitPolicyOptions() {
       tracking_options->set_internal_tracking_direction(
           TrackingOptions::FLOW_DIRECTION_FORWARD);
       tracking_options->set_tracking_policy(
-          TrackingOptions::FLOW_DIRECTION_POLICY_LONG_TRACKS);
+          TrackingOptions::TRACKING_POLICY_LONG_TRACKS);
 
       feature_bias_options->set_use_spatial_bias(false);
       feature_bias_options->set_seed_priors_from_bias(true);
@@ -303,7 +303,7 @@ void MotionAnalysis::InitPolicyOptions() {
 
       // Speed.
       flow_options->set_downsample_mode(
-          RegionFlowComputationOptions::REGION_FLOW_DOWNSAMPLE_BY_SCHEDULE);
+          RegionFlowComputationOptions::DOWNSAMPLE_MODE_BY_SCHEDULE);
 
       // Less quality features.
       flow_options->set_absolute_inlier_error_threshold(4);
@@ -383,7 +383,7 @@ bool MotionAnalysis::AddFrameGeneric(
     // tracking has been requested.
     int max_track_index = 0;
     if (options_.flow_options().tracking_options().tracking_policy() ==
-        TrackingOptions::FLOW_DIRECTION_POLICY_MULTI_FRAME) {
+        TrackingOptions::TRACKING_POLICY_MULTI_FRAME) {
       max_track_index = std::min(
           options_.flow_options().tracking_options().multi_frames_to_track() -
               1,

--- a/mediapipe/util/tracking/motion_estimation.cc
+++ b/mediapipe/util/tracking/motion_estimation.cc
@@ -748,7 +748,7 @@ class EstimateMotionIRLSInvoker {
       return;
     }
 
-    if (camera_motion->flags() & CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SINGULAR_ESTIMATION) {
+    if (camera_motion->flags() & CameraMotion::CAMERA_MOTION_FLAG_SINGULAR_ESTIMATION) {
       // If motion became singular in earlier iteration, skip.
       return;
     }
@@ -842,13 +842,13 @@ void MotionEstimation::EstimateMotionsParallelImpl(
     // Assume motions to be VALID in case they contain features.
     // INVALID (= empty frames) wont be considered during motion estimation.
     if (feature_list.feature_size() != 0) {
-      camera_motion.set_type(CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_VALID);
+      camera_motion.set_type(CameraMotion::CAMERA_MOTION_TYPE_VALID);
     }
 
     // Flag duplicated frames.
     if (feature_list.is_duplicated()) {
       camera_motion.set_flags(camera_motion.flags() |
-                              CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_DUPLICATED);
+                              CameraMotion::CAMERA_MOTION_FLAG_DUPLICATED);
     }
   }
 
@@ -1033,7 +1033,7 @@ void MotionEstimation::EstimateMotionsParallelImpl(
                     MODEL_AVERAGE_MAGNITUDE,
                     1,     // Does not use irls.
                     true,  // Compute stability.
-                    CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_VALID, DefaultModelOptions(), this,
+                    CameraMotion::CAMERA_MOTION_TYPE_VALID, DefaultModelOptions(), this,
                     nullptr,  // No prior weights.
                     nullptr,  // No thread storage.
                     clip_data.feature_lists, clip_data.camera_motions));
@@ -1045,13 +1045,13 @@ void MotionEstimation::EstimateMotionsParallelImpl(
 
   // Estimate translations, regardless of stability of similarity.
   EstimateMotionModels(MODEL_TRANSLATION,
-                       CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE,  // Any but invalid.
+                       CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE,  // Any but invalid.
                        DefaultModelOptions(),
                        nullptr,  // No thread storage.
                        &clip_datas);
 
   // Estimate linear similarity, but only if translation was deemed stable.
-  EstimateMotionModels(MODEL_LINEAR_SIMILARITY, CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_VALID,
+  EstimateMotionModels(MODEL_LINEAR_SIMILARITY, CameraMotion::CAMERA_MOTION_TYPE_VALID,
                        DefaultModelOptions(),
                        nullptr,  // No thread storage.
                        &clip_datas);
@@ -1061,7 +1061,7 @@ void MotionEstimation::EstimateMotionsParallelImpl(
   }
 
   // Estimate affine, but only if similarity was deemed stable.
-  EstimateMotionModels(MODEL_AFFINE, CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_VALID, DefaultModelOptions(),
+  EstimateMotionModels(MODEL_AFFINE, CameraMotion::CAMERA_MOTION_TYPE_VALID, DefaultModelOptions(),
                        nullptr,  // No thread storage.
                        &clip_datas);
 
@@ -1069,7 +1069,7 @@ void MotionEstimation::EstimateMotionsParallelImpl(
   MotionEstimationThreadStorage thread_storage(options_, this, max_features);
 
   // Estimate homographies, only if similarity was deemed stable.
-  EstimateMotionModels(MODEL_HOMOGRAPHY, CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_VALID,
+  EstimateMotionModels(MODEL_HOMOGRAPHY, CameraMotion::CAMERA_MOTION_TYPE_VALID,
                        DefaultModelOptions(), &thread_storage, &clip_datas);
 
   if (options_.project_valid_motions_down()) {
@@ -1106,7 +1106,7 @@ void MotionEstimation::EstimateMotionsParallelImpl(
     // mixtures only if weakest mixture was deemed stable.
     const bool estimate_result = EstimateMotionModels(
         MODEL_MIXTURE_HOMOGRAPHY,
-        m == 0 ? CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE : CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_VALID, options,
+        m == 0 ? CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE : CameraMotion::CAMERA_MOTION_TYPE_VALID, options,
         &thread_storage, &clip_datas);
 
     if (m == 0) {
@@ -1120,7 +1120,7 @@ void MotionEstimation::EstimateMotionsParallelImpl(
     // computed w.r.t. it).
     if (base_mixture_estimated && m > 0) {
       for (auto& clip_data : clip_datas) {
-        clip_data.RestoreWeightsFromBackup(CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_VALID);
+        clip_data.RestoreWeightsFromBackup(CameraMotion::CAMERA_MOTION_TYPE_VALID);
       }
     }
   }
@@ -1147,7 +1147,7 @@ void MotionEstimation::EstimateMotionsParallelImpl(
     for (int f = 0; f < num_frames; ++f) {
       CameraMotion& camera_motion = (*camera_motions)[f];
       if ((*feature_lists)[f]->feature_size() == 0) {
-        camera_motion.set_type(CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_VALID);
+        camera_motion.set_type(CameraMotion::CAMERA_MOTION_TYPE_VALID);
       }
     }
   }
@@ -1198,7 +1198,7 @@ bool MotionEstimation::EstimateMotionModels(
   for (auto& clip_data : *clip_datas) {
     clip_data.SetupPriorWeights(irls_per_round);
     // Clear flag from earlier model estimation.
-    clip_data.ClearFlagFromMotion(CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SINGULAR_ESTIMATION);
+    clip_data.ClearFlagFromMotion(CameraMotion::CAMERA_MOTION_FLAG_SINGULAR_ESTIMATION);
   }
 
   if (options_.estimation_policy() !=
@@ -1302,7 +1302,7 @@ bool MotionEstimation::EstimateMotionModels(
                                       &clip_data.camera_motions->at(k));
           }
 
-          if (clip_data.camera_motions->at(k).type() == CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_VALID) {
+          if (clip_data.camera_motions->at(k).type() == CameraMotion::CAMERA_MOTION_TYPE_VALID) {
             const bool remove_terminated_tracks =
                 total_rounds == 1 || (round == 0 && k == 0);
             UpdateLongFeatureBias(type, model_options, remove_terminated_tracks,
@@ -1520,7 +1520,7 @@ class IrlsInitializationInvoker {
       switch (type_) {
         case MotionEstimation::MODEL_HOMOGRAPHY:
           if (use_only_lin_sim_inliers_for_homography &&
-              camera_motion.type() <= CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE_SIM) {
+              camera_motion.type() <= CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE_SIM) {
             // Threshold is set w.r.t. normalized frame diameter.
             LinearSimilarityModel normalized_similarity =
                 ModelCompose3(motion_estimation_->normalization_transform_,
@@ -1536,7 +1536,7 @@ class IrlsInitializationInvoker {
 
         case MotionEstimation::MODEL_MIXTURE_HOMOGRAPHY:
           if (use_only_lin_sim_inliers_for_homography &&
-              camera_motion.type() <= CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE_SIM) {
+              camera_motion.type() <= CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE_SIM) {
             // Threshold is set w.r.t. normalized frame diameter.
             LinearSimilarityModel normalized_similarity =
                 ModelCompose3(motion_estimation_->normalization_transform_,
@@ -2479,7 +2479,7 @@ void MotionEstimation::CheckSingleModelStability(
                               *feature_list)) {
         // Translation can never be singular.
         ABSL_CHECK_EQ(
-            0, camera_motion->flags() & CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SINGULAR_ESTIMATION);
+            0, camera_motion->flags() & CameraMotion::CAMERA_MOTION_FLAG_SINGULAR_ESTIMATION);
       } else {
         // Invalid model.
         if (reset_irls_weights) {
@@ -2493,7 +2493,7 @@ void MotionEstimation::CheckSingleModelStability(
       const int num_inliers =
           std::round(feature_list->feature_size() *
                      camera_motion->similarity_inlier_ratio());
-      if (camera_motion->flags() & CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SINGULAR_ESTIMATION ||
+      if (camera_motion->flags() & CameraMotion::CAMERA_MOTION_FLAG_SINGULAR_ESTIMATION ||
           !IsStableSimilarity(camera_motion->linear_similarity(), *feature_list,
                               num_inliers)) {
         if (reset_irls_weights) {
@@ -2510,7 +2510,7 @@ void MotionEstimation::CheckSingleModelStability(
       break;
 
     case MODEL_HOMOGRAPHY:
-      if (camera_motion->flags() & CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SINGULAR_ESTIMATION ||
+      if (camera_motion->flags() & CameraMotion::CAMERA_MOTION_FLAG_SINGULAR_ESTIMATION ||
           !IsStableHomography(camera_motion->homography(),
                               camera_motion->average_homography_error(),
                               camera_motion->homography_inlier_coverage())) {
@@ -2529,7 +2529,7 @@ void MotionEstimation::CheckSingleModelStability(
       const float mix_min_inlier_coverage =
           options_.stable_mixture_homography_bounds().min_inlier_coverage();
 
-      if (camera_motion->flags() & CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SINGULAR_ESTIMATION ||
+      if (camera_motion->flags() & CameraMotion::CAMERA_MOTION_FLAG_SINGULAR_ESTIMATION ||
           !IsStableMixtureHomography(camera_motion->mixture_homography(),
                                      mix_min_inlier_coverage, block_coverage)) {
         // Unstable homography mixture.
@@ -2540,25 +2540,25 @@ void MotionEstimation::CheckSingleModelStability(
         // (UNSTABLE_HOMOG flag is set by this function only during
         //  ResetToHomography below).
         switch (camera_motion->type()) {
-          case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_VALID:
+          case CameraMotion::CAMERA_MOTION_TYPE_VALID:
             // Homography deemed stable, fallback to it.
             MotionEstimation::ResetToHomography(camera_motion->homography(),
                                                 true,  // flag_as_unstable_model
                                                 camera_motion);
             break;
 
-          case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE_SIM:
+          case CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE_SIM:
             MotionEstimation::ResetToSimilarity(
                 camera_motion->linear_similarity(), camera_motion);
             break;
 
-          case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE:
+          case CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE:
             MotionEstimation::ResetToTranslation(camera_motion->translation(),
                                                  camera_motion);
             break;
 
-          case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_INVALID:
-          case CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE_HOMOG:
+          case CameraMotion::CAMERA_MOTION_TYPE_INVALID:
+          case CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE_HOMOG:
             ABSL_LOG(FATAL)
                 << "Unexpected CameraMotion::Type: " << camera_motion->type();
             break;
@@ -2574,7 +2574,7 @@ void MotionEstimation::CheckSingleModelStability(
       } else {
         // Stable mixture homography can reset unstable type.
         camera_motion->set_overridden_type(camera_motion->type());
-        camera_motion->set_type(CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_VALID);
+        camera_motion->set_type(CameraMotion::CAMERA_MOTION_TYPE_VALID);
         // Select weakest regularized mixture.
         camera_motion->set_rolling_shutter_motion_index(0);
       }
@@ -2604,7 +2604,7 @@ void MotionEstimation::ProjectMotionsDown(
         // Only project down if model was estimated, otherwise would propagate
         // identity.
         if (camera_motion.has_homography() &&
-            camera_motion.type() <= CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE_HOMOG) {
+            camera_motion.type() <= CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE_HOMOG) {
           LinearSimilarityModel lin_sim =
               *camera_motion.mutable_linear_similarity() =
                   AffineAdapter::ProjectToLinearSimilarity(
@@ -2619,7 +2619,7 @@ void MotionEstimation::ProjectMotionsDown(
       case MODEL_LINEAR_SIMILARITY:
         // Only project down if model was estimated.
         if (camera_motion.has_linear_similarity() &&
-            camera_motion.type() <= CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE_SIM) {
+            camera_motion.type() <= CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE_SIM) {
           *camera_motion.mutable_translation() =
               LinearSimilarityAdapter::ProjectToTranslation(
                   camera_motion.linear_similarity(), frame_width_,
@@ -2712,19 +2712,19 @@ void MotionEstimation::DetermineShotBoundaries(
   const int num_motions = camera_motions->size();
   for (int k = 0; k < num_motions; ++k) {
     auto& camera_motion = (*camera_motions)[k];
-    if (camera_motion.type() == CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_INVALID ||
+    if (camera_motion.type() == CameraMotion::CAMERA_MOTION_TYPE_INVALID ||
         feature_lists[k]->feature_size() == 0) {
       // Potential shot boundary, verify.
       if (feature_lists[k]->visual_consistency() >= 0) {
         if (feature_lists[k]->visual_consistency() >=
             shot_options.motion_consistency_threshold()) {
           camera_motion.set_flags(camera_motion.flags() |
-                                  CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SHOT_BOUNDARY);
+                                  CameraMotion::CAMERA_MOTION_FLAG_SHOT_BOUNDARY);
         }
       } else {
         // No consistency present, label as shot boundary.
         camera_motion.set_flags(camera_motion.flags() |
-                                CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SHOT_BOUNDARY);
+                                CameraMotion::CAMERA_MOTION_FLAG_SHOT_BOUNDARY);
       }
     }
   }
@@ -2740,24 +2740,24 @@ void MotionEstimation::DetermineShotBoundaries(
         // Only add boundaries if previous or next frame are not already labeled
         // boundaries by above tests.
         if (k > 0 && ((*camera_motions)[k - 1].flags() &
-                      CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SHOT_BOUNDARY) != 0) {
+                      CameraMotion::CAMERA_MOTION_FLAG_SHOT_BOUNDARY) != 0) {
           continue;
         }
         if (k + 1 < num_motions && ((*camera_motions)[k + 1].flags() &
-                                    CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SHOT_BOUNDARY) != 0) {
+                                    CameraMotion::CAMERA_MOTION_FLAG_SHOT_BOUNDARY) != 0) {
           continue;
         }
 
         // Shot boundaries based on visual consistency measure.
         camera_motion.set_flags(camera_motion.flags() |
-                                CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SHOT_BOUNDARY);
+                                CameraMotion::CAMERA_MOTION_FLAG_SHOT_BOUNDARY);
       }
     }
   }
 
   // LOG shot boundaries.
   for (const auto& camera_motion : *camera_motions) {
-    if (camera_motion.flags() & CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SHOT_BOUNDARY) {
+    if (camera_motion.flags() & CameraMotion::CAMERA_MOTION_FLAG_SHOT_BOUNDARY) {
       VLOG(1) << "Shot boundary at : " << camera_motion.timestamp_usec() * 1e-6f
               << "s";
     }
@@ -2806,7 +2806,7 @@ void MotionEstimation::ResetMotionModels(const MotionEstimationOptions& options,
     camera_motion->set_mixture_row_sigma(options.mixture_row_sigma());
   }
 
-  camera_motion->set_type(CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_INVALID);
+  camera_motion->set_type(CameraMotion::CAMERA_MOTION_TYPE_INVALID);
 }
 
 void MotionEstimation::ResetToIdentity(CameraMotion* camera_motion,
@@ -2840,9 +2840,9 @@ void MotionEstimation::ResetToIdentity(CameraMotion* camera_motion,
   }
 
   if (consider_valid) {
-    camera_motion->set_type(CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_VALID);
+    camera_motion->set_type(CameraMotion::CAMERA_MOTION_TYPE_VALID);
   } else {
-    camera_motion->set_type(CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_INVALID);
+    camera_motion->set_type(CameraMotion::CAMERA_MOTION_TYPE_INVALID);
   }
 }
 
@@ -2885,7 +2885,7 @@ void MotionEstimation::ResetToTranslation(const TranslationModel& model,
         MixtureHomography::CONST_DOF);
   }
 
-  camera_motion->set_type(CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE);
+  camera_motion->set_type(CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE);
 }
 
 void MotionEstimation::ResetToSimilarity(const LinearSimilarityModel& model,
@@ -2920,7 +2920,7 @@ void MotionEstimation::ResetToSimilarity(const LinearSimilarityModel& model,
         MixtureHomography::CONST_DOF);
   }
 
-  camera_motion->set_type(CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE_SIM);
+  camera_motion->set_type(CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE_SIM);
 }
 
 void MotionEstimation::ResetToHomography(const Homography& model,
@@ -2942,7 +2942,7 @@ void MotionEstimation::ResetToHomography(const Homography& model,
   }
 
   if (flag_as_unstable_model) {
-    camera_motion->set_type(CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_UNSTABLE_HOMOG);
+    camera_motion->set_type(CameraMotion::CAMERA_MOTION_TYPE_UNSTABLE_HOMOG);
   }
 }
 
@@ -3584,7 +3584,7 @@ bool MotionEstimation::EstimateLinearSimilarityModelIRLS(
       VLOG(1) << "Linear similarity estimation failed.";
       *camera_motion->mutable_linear_similarity() = LinearSimilarityModel();
       camera_motion->set_flags(camera_motion->flags() |
-                               CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SINGULAR_ESTIMATION);
+                               CameraMotion::CAMERA_MOTION_FLAG_SINGULAR_ESTIMATION);
       return false;
     }
 
@@ -3691,7 +3691,7 @@ bool MotionEstimation::EstimateAffineModelIRLS(
     p = matrix.colPivHouseholderQr().solve(rhs);
     if (!(matrix * p).isApprox(rhs, kPrecision)) {
       camera_motion->set_flags(camera_motion->flags() |
-                               CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SINGULAR_ESTIMATION);
+                               CameraMotion::CAMERA_MOTION_FLAG_SINGULAR_ESTIMATION);
       return false;
     }
 
@@ -4895,7 +4895,7 @@ bool MotionEstimation::EstimateHomographyIRLS(
             << min_features_for_solution << " features usable for estimation.";
     *camera_motion->mutable_homography() = Homography();
     camera_motion->set_flags(camera_motion->flags() |
-                             CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SINGULAR_ESTIMATION);
+                             CameraMotion::CAMERA_MOTION_FLAG_SINGULAR_ESTIMATION);
     return false;
   }
 
@@ -4964,7 +4964,7 @@ bool MotionEstimation::EstimateHomographyIRLS(
         VLOG(1) << "Could not solve for homography.";
         *camera_motion->mutable_homography() = Homography();
         camera_motion->set_flags(camera_motion->flags() |
-                                 CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SINGULAR_ESTIMATION);
+                                 CameraMotion::CAMERA_MOTION_FLAG_SINGULAR_ESTIMATION);
         return false;
       }
       norm_model =
@@ -4988,7 +4988,7 @@ bool MotionEstimation::EstimateHomographyIRLS(
         VLOG(1) << "Could not solve for homography.";
         *camera_motion->mutable_homography() = Homography();
         camera_motion->set_flags(camera_motion->flags() |
-                                 CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SINGULAR_ESTIMATION);
+                                 CameraMotion::CAMERA_MOTION_FLAG_SINGULAR_ESTIMATION);
         return false;
       }
     }
@@ -5312,7 +5312,7 @@ bool MotionEstimation::EstimateMixtureHomographyIRLS(
     VLOG(1) << "Mixture homography estimation not possible, less than "
             << min_features_for_solution << " features present.";
     camera_motion->set_flags(camera_motion->flags() |
-                             CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SINGULAR_ESTIMATION);
+                             CameraMotion::CAMERA_MOTION_FLAG_SINGULAR_ESTIMATION);
     return false;
   }
 
@@ -5323,7 +5323,7 @@ bool MotionEstimation::EstimateMixtureHomographyIRLS(
     VLOG(1) << "Non-rigid homography estimated. "
             << "CameraMotion flagged as unstable.";
     camera_motion->set_flags(camera_motion->flags() |
-                             CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SINGULAR_ESTIMATION);
+                             CameraMotion::CAMERA_MOTION_FLAG_SINGULAR_ESTIMATION);
     return false;
   }
 
@@ -5343,7 +5343,7 @@ bool MotionEstimation::EstimateMixtureHomographyIRLS(
       if (!invertible) {
         VLOG(1) << "Mixture is not invertible.";
         camera_motion->set_flags(camera_motion->flags() |
-                                 CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_FLAG_SINGULAR_ESTIMATION);
+                                 CameraMotion::CAMERA_MOTION_FLAG_SINGULAR_ESTIMATION);
         return false;
       }
     }
@@ -5475,7 +5475,7 @@ void MotionEstimation::DetermineOverlayIndices(
 
   ParallelFor(0, num_frames, 1,
               EstimateMotionIRLSInvoker(MODEL_TRANSLATION, irls_per_round,
-                                        false, CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_VALID,
+                                        false, CameraMotion::CAMERA_MOTION_TYPE_VALID,
                                         DefaultModelOptions(), this,
                                         nullptr,  // No prior weights.
                                         nullptr,  // No thread storage here.

--- a/mediapipe/util/tracking/motion_estimation.proto
+++ b/mediapipe/util/tracking/motion_estimation.proto
@@ -594,7 +594,7 @@ message MotionEstimationOptions {
 
   // Shot boundaries are introduced in 3 different scenarios:
   // a) Frame has zero tracked features w.r.t. previous frame
-  // b) Estimated motion is deemed invalid (CameraMotion::CAMERA_MOTION_CAMERA_MOTION_TYPE_INVALID).
+  // b) Estimated motion is deemed invalid (CameraMotion::CAMERA_MOTION_TYPE_INVALID).
   // c) Visual consistency is above threshold of two adjacent frames.
   message ShotBoundaryOptions {
     // After cases a & b are determined from features/camera motion, they

--- a/mediapipe/util/tracking/region_flow_computation.cc
+++ b/mediapipe/util/tracking/region_flow_computation.cc
@@ -554,11 +554,11 @@ RegionFlowComputation::RegionFlowComputation(
       frame_width_(frame_width),
       frame_height_(frame_height) {
   switch (options_.gain_correct_mode()) {
-    case RegionFlowComputationOptions::REGION_FLOW_GAIN_CORRECT_DEFAULT_USER:
+    case RegionFlowComputationOptions::GAIN_CORRECT_MODE_DEFAULT_USER:
       // Do nothing, simply use supplied bounds.
       break;
 
-    case RegionFlowComputationOptions::REGION_FLOW_GAIN_CORRECT_VIDEO: {
+    case RegionFlowComputationOptions::GAIN_CORRECT_MODE_VIDEO: {
       auto* gain_bias = options_.mutable_gain_bias_bounds();
       gain_bias->Clear();
       gain_bias->set_lower_gain(0.8f);
@@ -570,7 +570,7 @@ RegionFlowComputation::RegionFlowComputation(
       break;
     }
 
-    case RegionFlowComputationOptions::REGION_FLOW_GAIN_CORRECT_HDR: {
+    case RegionFlowComputationOptions::GAIN_CORRECT_MODE_HDR: {
       auto* gain_bias = options_.mutable_gain_bias_bounds();
       gain_bias->Clear();
       gain_bias->set_lower_gain(0.8f);
@@ -583,7 +583,7 @@ RegionFlowComputation::RegionFlowComputation(
       break;
     }
 
-    case RegionFlowComputationOptions::REGION_FLOW_GAIN_CORRECT_PHOTO_BURST: {
+    case RegionFlowComputationOptions::GAIN_CORRECT_MODE_PHOTO_BURST: {
       auto* gain_bias = options_.mutable_gain_bias_bounds();
       gain_bias->Clear();
       gain_bias->set_min_inlier_fraction(0.6f);
@@ -600,15 +600,15 @@ RegionFlowComputation::RegionFlowComputation(
                 TrackingOptions::FLOW_DIRECTION_CONSECUTIVELY)
       << "Output direction must be either set to FORWARD or BACKWARD.";
   use_downsampling_ = options_.downsample_mode() !=
-                      RegionFlowComputationOptions::REGION_FLOW_DOWNSAMPLE_NONE;
+                      RegionFlowComputationOptions::DOWNSAMPLE_MODE_NONE;
   downsample_scale_ = 1;
   original_width_ = frame_width_;
   original_height_ = frame_height_;
 
   switch (options_.downsample_mode()) {
-    case RegionFlowComputationOptions::REGION_FLOW_DOWNSAMPLE_NONE:
+    case RegionFlowComputationOptions::DOWNSAMPLE_MODE_NONE:
       break;
-    case RegionFlowComputationOptions::REGION_FLOW_DOWNSAMPLE_TO_MAX_SIZE: {
+    case RegionFlowComputationOptions::DOWNSAMPLE_MODE_TO_MAX_SIZE: {
       const float max_size = std::max(frame_width_, frame_height_);
       if (max_size > 1.03f * options_.downsampling_size()) {
         downsample_scale_ = max_size / options_.downsampling_size();
@@ -618,7 +618,7 @@ RegionFlowComputation::RegionFlowComputation(
       }
       break;
     }
-    case RegionFlowComputationOptions::REGION_FLOW_DOWNSAMPLE_TO_MIN_SIZE: {
+    case RegionFlowComputationOptions::DOWNSAMPLE_MODE_TO_MIN_SIZE: {
       const float min_size = std::min(frame_width_, frame_height_);
       if (min_size > 1.03f * options_.downsampling_size()) {
         downsample_scale_ = min_size / options_.downsampling_size();
@@ -628,13 +628,13 @@ RegionFlowComputation::RegionFlowComputation(
       }
       break;
     }
-    case RegionFlowComputationOptions::REGION_FLOW_DOWNSAMPLE_BY_FACTOR:
-    case RegionFlowComputationOptions::REGION_FLOW_DOWNSAMPLE_TO_INPUT_SIZE: {
+    case RegionFlowComputationOptions::DOWNSAMPLE_MODE_BY_FACTOR:
+    case RegionFlowComputationOptions::DOWNSAMPLE_MODE_TO_INPUT_SIZE: {
       ABSL_CHECK_GE(options_.downsample_factor(), 1);
       downsample_scale_ = options_.downsample_factor();
       break;
     }
-    case RegionFlowComputationOptions::REGION_FLOW_DOWNSAMPLE_BY_SCHEDULE: {
+    case RegionFlowComputationOptions::DOWNSAMPLE_MODE_BY_SCHEDULE: {
       const int frame_area = frame_width_ * frame_height_;
       if (frame_area <= (16 * 1.03 / 9 * 360 * 360)) {
         downsample_scale_ =
@@ -658,7 +658,7 @@ RegionFlowComputation::RegionFlowComputation(
 
   if (use_downsampling_ &&
       options_.downsample_mode() !=
-          RegionFlowComputationOptions::REGION_FLOW_DOWNSAMPLE_TO_INPUT_SIZE) {
+          RegionFlowComputationOptions::DOWNSAMPLE_MODE_TO_INPUT_SIZE) {
     // Make downscaled size even.
     frame_width_ += frame_width_ % 2;
     frame_height_ += frame_height_ % 2;
@@ -673,19 +673,19 @@ RegionFlowComputation::RegionFlowComputation(
 
   // Allocate temporary frames.
   switch (options_.image_format()) {
-    case RegionFlowComputationOptions::REGION_FLOW_FORMAT_RGB:
-    case RegionFlowComputationOptions::REGION_FLOW_FORMAT_BGR:
+    case RegionFlowComputationOptions::IMAGE_FORMAT_RGB:
+    case RegionFlowComputationOptions::IMAGE_FORMAT_BGR:
       curr_color_image_.reset(
           new cv::Mat(frame_height_, frame_width_, CV_8UC3));
       break;
 
-    case RegionFlowComputationOptions::REGION_FLOW_FORMAT_RGBA:
-    case RegionFlowComputationOptions::REGION_FLOW_FORMAT_BGRA:
+    case RegionFlowComputationOptions::IMAGE_FORMAT_RGBA:
+    case RegionFlowComputationOptions::IMAGE_FORMAT_BGRA:
       curr_color_image_.reset(
           new cv::Mat(frame_height_, frame_width_, CV_8UC4));
       break;
 
-    case RegionFlowComputationOptions::REGION_FLOW_FORMAT_GRAYSCALE:
+    case RegionFlowComputationOptions::IMAGE_FORMAT_GRAYSCALE:
       // Do nothing.
       break;
   }
@@ -698,7 +698,7 @@ RegionFlowComputation::RegionFlowComputation(
 
   max_long_track_length_ = 1;
   switch (options_.tracking_options().tracking_policy()) {
-    case TrackingOptions::FLOW_DIRECTION_POLICY_SINGLE_FRAME:
+    case TrackingOptions::TRACKING_POLICY_SINGLE_FRAME:
       if (options_.tracking_options().multi_frames_to_track() > 1) {
         ABSL_LOG(ERROR) << "TrackingOptions::multi_frames_to_track is > 1, "
                         << "but tracking_policy is set to POLICY_SINGLE_FRAME. "
@@ -707,11 +707,11 @@ RegionFlowComputation::RegionFlowComputation(
 
       frames_to_track_ = 1;
       break;
-    case TrackingOptions::FLOW_DIRECTION_POLICY_MULTI_FRAME:
+    case TrackingOptions::TRACKING_POLICY_MULTI_FRAME:
       ABSL_CHECK_GT(options_.tracking_options().multi_frames_to_track(), 0);
       frames_to_track_ = options_.tracking_options().multi_frames_to_track();
       break;
-    case TrackingOptions::FLOW_DIRECTION_POLICY_LONG_TRACKS:
+    case TrackingOptions::TRACKING_POLICY_LONG_TRACKS:
       if (options_.tracking_options().multi_frames_to_track() > 1) {
         ABSL_LOG(ERROR) << "TrackingOptions::multi_frames_to_track is > 1, "
                         << "but tracking_policy is set to POLICY_LONG_TRACKS. "
@@ -906,7 +906,7 @@ bool RegionFlowComputation::InitFrame(const cv::Mat& source,
   const cv::Mat* source_ptr = &source;
   if (use_downsampling_ &&
       options_.downsample_mode() !=
-          RegionFlowComputationOptions::REGION_FLOW_DOWNSAMPLE_TO_INPUT_SIZE) {
+          RegionFlowComputationOptions::DOWNSAMPLE_MODE_TO_INPUT_SIZE) {
     // Area based method best for downsampling.
     // For color images to temporary buffer.
     cv::Mat& resized = source.channels() == 1 ? dest_frame : *curr_color_image_;
@@ -935,15 +935,15 @@ bool RegionFlowComputation::InitFrame(const cv::Mat& source,
 
   if (source_ptr->channels() == 1 &&
       options_.image_format() !=
-          RegionFlowComputationOptions::REGION_FLOW_FORMAT_GRAYSCALE) {
-    options_.set_image_format(RegionFlowComputationOptions::REGION_FLOW_FORMAT_GRAYSCALE);
+          RegionFlowComputationOptions::IMAGE_FORMAT_GRAYSCALE) {
+    options_.set_image_format(RegionFlowComputationOptions::IMAGE_FORMAT_GRAYSCALE);
     ABSL_LOG(WARNING) << "#channels = 1, but image_format was not set to "
                          "FORMAT_GRAYSCALE. Assuming GRAYSCALE input.";
   }
 
   // Convert image to grayscale.
   switch (options_.image_format()) {
-    case RegionFlowComputationOptions::REGION_FLOW_FORMAT_RGB:
+    case RegionFlowComputationOptions::IMAGE_FORMAT_RGB:
       if (3 != source_ptr->channels()) {
         ABSL_LOG(ERROR) << "Expecting 3 channel input for RGB.";
         return false;
@@ -951,7 +951,7 @@ bool RegionFlowComputation::InitFrame(const cv::Mat& source,
       cv::cvtColor(*source_ptr, dest_frame, cv::COLOR_RGB2GRAY);
       break;
 
-    case RegionFlowComputationOptions::REGION_FLOW_FORMAT_BGR:
+    case RegionFlowComputationOptions::IMAGE_FORMAT_BGR:
       if (3 != source_ptr->channels()) {
         ABSL_LOG(ERROR) << "Expecting 3 channel input for BGR.";
         return false;
@@ -959,7 +959,7 @@ bool RegionFlowComputation::InitFrame(const cv::Mat& source,
       cv::cvtColor(*source_ptr, dest_frame, cv::COLOR_BGR2GRAY);
       break;
 
-    case RegionFlowComputationOptions::REGION_FLOW_FORMAT_RGBA:
+    case RegionFlowComputationOptions::IMAGE_FORMAT_RGBA:
       if (4 != source_ptr->channels()) {
         ABSL_LOG(ERROR) << "Expecting 4 channel input for RGBA.";
         return false;
@@ -967,7 +967,7 @@ bool RegionFlowComputation::InitFrame(const cv::Mat& source,
       cv::cvtColor(*source_ptr, dest_frame, cv::COLOR_RGBA2GRAY);
       break;
 
-    case RegionFlowComputationOptions::REGION_FLOW_FORMAT_BGRA:
+    case RegionFlowComputationOptions::IMAGE_FORMAT_BGRA:
       if (4 != source_ptr->channels()) {
         ABSL_LOG(ERROR) << "Expecting 4 channel input for BGRA.";
         return false;
@@ -975,7 +975,7 @@ bool RegionFlowComputation::InitFrame(const cv::Mat& source,
       cv::cvtColor(*source_ptr, dest_frame, cv::COLOR_BGRA2GRAY);
       break;
 
-    case RegionFlowComputationOptions::REGION_FLOW_FORMAT_GRAYSCALE:
+    case RegionFlowComputationOptions::IMAGE_FORMAT_GRAYSCALE:
       if (1 != source_ptr->channels()) {
         ABSL_LOG(ERROR) << "Expecting 1 channel input for GRAYSCALE.";
         return false;
@@ -1015,7 +1015,7 @@ bool RegionFlowComputation::AddImageAndTrack(
   MEASURE_TIME << "AddImageAndTrack";
 
   if (options_.downsample_mode() ==
-      RegionFlowComputationOptions::REGION_FLOW_DOWNSAMPLE_TO_INPUT_SIZE) {
+      RegionFlowComputationOptions::DOWNSAMPLE_MODE_TO_INPUT_SIZE) {
     if (frame_width_ != source.cols || frame_height_ != source.rows) {
       ABSL_LOG(ERROR) << "Source input dimensions incompatible with "
                       << "DOWNSAMPLE_TO_INPUT_SIZE. frame_width_: "
@@ -1635,7 +1635,7 @@ void RegionFlowComputation::AdaptiveGoodFeaturesToTrack(
   block_height = max(1, block_height);
 
   bool use_harris = tracking_options.corner_extraction_method() ==
-                    TrackingOptions::FLOW_DIRECTION_EXTRACTION_HARRIS;
+                    TrackingOptions::CORNER_EXTRACTION_METHOD_HARRIS;
 
   const int adaptive_levels =
       options_.tracking_options().adaptive_features_levels();
@@ -1653,7 +1653,7 @@ void RegionFlowComputation::AdaptiveGoodFeaturesToTrack(
           : tracking_options.min_eig_val_settings().feature_quality_level();
 
   bool use_fast = tracking_options.corner_extraction_method() ==
-                  TrackingOptions::FLOW_DIRECTION_EXTRACTION_FAST;
+                  TrackingOptions::CORNER_EXTRACTION_METHOD_FAST;
   cv::Ptr<cv::FastFeatureDetector> fast_detector;
   if (use_fast) {
     fast_detector = cv::FastFeatureDetector::create(
@@ -2578,7 +2578,7 @@ void RegionFlowComputation::TrackFeatures(FrameTrackingData* from_data_ptr,
   }
 
   if (options_.tracking_options().klt_tracker_implementation() ==
-      TrackingOptions::FLOW_DIRECTION_KLT_OPENCV) {
+      TrackingOptions::KLT_OPENCV) {
     cv::calcOpticalFlowPyrLK(input_frame1, input_frame2, features1, features2,
                              feature_status_, feature_track_error_,
                              cv_window_size, pyramid_levels_, cv_criteria,
@@ -3346,11 +3346,11 @@ float RegionFlowComputation::TrackedFeatureViewToRegionFlowFeatureList(
     feature->set_flags(feature_ptr->flags);
 
     switch (options_.irls_initialization()) {
-      case RegionFlowComputationOptions::REGION_FLOW_INIT_UNIFORM:
+      case RegionFlowComputationOptions::IRIS_INIT_UNIFORM:
         feature->set_irls_weight(1.0f);
         break;
 
-      case RegionFlowComputationOptions::REGION_FLOW_INIT_CONSISTENCY:
+      case RegionFlowComputationOptions::IRIS_INIT_CONSISTENCY:
         feature->set_irls_weight(2.0f * feature_ptr->irls_weight /
                                  feature_ptr->num_bins);
         break;

--- a/mediapipe/util/tracking/region_flow_computation.proto
+++ b/mediapipe/util/tracking/region_flow_computation.proto
@@ -66,15 +66,15 @@ message TrackingOptions {
   // TRACK_ACROSS_FRAMES. Maximum track length can be specified by
   // long_tracks_max_frames.
   enum TrackingPolicy {
-    POLICY_UNKNOWN = 0;
-    POLICY_SINGLE_FRAME = 1;  // Tracks w.r.t. previous or next frame.
-    POLICY_MULTI_FRAME = 2;   // Tracks w.r.t. multiple frames.
-    POLICY_LONG_TRACKS = 3;   // Create long feature tracks.
-                              // Requires internal_tracking_direction to be
-                              // FORWARD. Checked against.
+    TRACKING_POLICY_UNKNOWN = 0;
+    TRACKING_POLICY_SINGLE_FRAME = 1;  // Tracks w.r.t. previous or next frame.
+    TRACKING_POLICY_MULTI_FRAME = 2;   // Tracks w.r.t. multiple frames.
+    TRACKING_POLICY_LONG_TRACKS = 3;   // Create long feature tracks.
+                                       // Requires internal_tracking_direction to be
+                                       // FORWARD. Checked against.
   }
 
-  optional TrackingPolicy tracking_policy = 25 [default = POLICY_SINGLE_FRAME];
+  optional TrackingPolicy tracking_policy = 25 [default = TRACKING_POLICY_SINGLE_FRAME];
 
   // Number of frame-pairs used for POLICY_MULTI_FRAME, ignored for other
   // policies.
@@ -98,15 +98,15 @@ message TrackingOptions {
 
   // Specifies the extraction method for features.
   enum CornerExtractionMethod {
-    EXTRACTION_UNKNOWN = 0;
-    EXTRACTION_HARRIS = 1;       // Using Harris' approximation of
-                                 // EXTRACTION_MIN_EIG_VAL.
-    EXTRACTION_MIN_EIG_VAL = 2;  // Exact smallest eigenvalue computation.
-    EXTRACTION_FAST = 3;         // Extract using FAST feature detector.
+    CORNER_EXTRACTION_METHOD_UNKNOWN = 0;
+    CORNER_EXTRACTION_METHOD_HARRIS = 1;       // Using Harris' approximation of
+                                               // EXTRACTION_MIN_EIG_VAL.
+    CORNER_EXTRACTION_METHOD_MIN_EIG_VAL = 2;  // Exact smallest eigenvalue computation.
+    CORNER_EXTRACTION_METHOD_FAST = 3;         // Extract using FAST feature detector.
   }
 
   optional CornerExtractionMethod corner_extraction_method = 27
-      [default = EXTRACTION_MIN_EIG_VAL];
+      [default = CORNER_EXTRACTION_METHOD_MIN_EIG_VAL];
 
   // Settings for above corner extraction methods.
   message MinEigValExtractionSettings {
@@ -232,7 +232,7 @@ message TrackingOptions {
   optional float reuse_features_min_survived_frac = 18 [default = 0.7];
 
   enum KltTrackerImplementation {
-    UNSPECIFIED = 0;
+    KLT_UNSPECIFIED = 0;
     KLT_OPENCV = 1;  // Use OpenCV's implementation of KLT tracker.
   }
 
@@ -310,20 +310,20 @@ message RegionFlowComputationOptions {
   // Determines how irls weights for computed features are initialized.
   // In general, more stable features are given higher weight.
   enum IrlsInitialization {
-    INIT_UNKNOWN = 0;
-    INIT_UNIFORM = 1;  // All weights equal 1
+    IRIS_INIT_UNKNOWN = 0;
+    IRIS_INIT_UNIFORM = 1;  // All weights equal 1
 
     // Feature's irls weight is initialized to a value in [0, 2]
     // indicating how consistent the feature's motion is w.r.t. neighboring
     // features (high values = very consistent). Determined by counting how
     // often a feature is part of the inlier set for a particular bin.
-    INIT_CONSISTENCY = 2;
+    IRIS_INIT_CONSISTENCY = 2;
   }
 
   // If this option is activated, feature's irls weight is initialized to the
   // inverse of its computed flow.
   optional IrlsInitialization irls_initialization = 49
-      [default = INIT_CONSISTENCY];
+      [default = IRIS_INIT_CONSISTENCY];
 
   // We support down-sampling of an incoming frame before running the
   // resolution dependent part of the region flow computation (feature
@@ -333,27 +333,27 @@ message RegionFlowComputationOptions {
   // the nearest even dimension, i.e. 350p with a downsample_factor of 2.0
   // would expect an input of size 176p.
   enum DownsampleMode {
-    REGION_FLOW_DOWNSAMPLE_UNKNOWN = 0;
+    DOWNSAMPLE_MODE_UNKNOWN = 0;
     // No downsampling.
-    REGION_FLOW_DOWNSAMPLE_NONE = 1;
+    DOWNSAMPLE_MODE_NONE = 1;
     // Downsizes the input frame such that frame_size == downsampling_size,
     // where frame_size := max(width, height).
-    REGION_FLOW_DOWNSAMPLE_TO_MAX_SIZE = 2;
+    DOWNSAMPLE_MODE_TO_MAX_SIZE = 2;
     // Downsizes frame by pre-defined factor, downsample_factor below.
-    REGION_FLOW_DOWNSAMPLE_BY_FACTOR = 3;
+    DOWNSAMPLE_MODE_BY_FACTOR = 3;
     // Downsampling based on downsampling schedule, see DownsampleSchedule below
     // for details.
-    REGION_FLOW_DOWNSAMPLE_BY_SCHEDULE = 4;
+    DOWNSAMPLE_MODE_BY_SCHEDULE = 4;
     // Downsizes the input frame such that frame_size == downsampling_size,
     // where frame_size := min(width, height).
-    REGION_FLOW_DOWNSAMPLE_TO_MIN_SIZE = 5;
+    DOWNSAMPLE_MODE_TO_MIN_SIZE = 5;
     // Input frame is assumed to be already downsampled by the factor specified
     // by downsample_factor below. For example if the original frame is 720p,
     // and downsample_factor is set to 2.0, then we expect as input 360p.
-    REGION_FLOW_DOWNSAMPLE_TO_INPUT_SIZE = 6;
+    DOWNSAMPLE_MODE_TO_INPUT_SIZE = 6;
   }
 
-  optional DownsampleMode downsample_mode = 11 [default = REGION_FLOW_DOWNSAMPLE_NONE];
+  optional DownsampleMode downsample_mode = 11 [default = DOWNSAMPLE_MODE_NONE];
 
   // Specify the size of either dimension here, the frame will be
   // downsampled to fit downsampling_size.
@@ -527,19 +527,19 @@ message RegionFlowComputationOptions {
   optional float frac_gain_step = 38 [default = 0.1];
 
   enum GainCorrectMode {
-    GAIN_CORRECT_DEFAULT_USER = 1;  // Uses default or user supplied bounds,
-                                    // i.e. gain_bias_bounds is left untouched.
-    GAIN_CORRECT_VIDEO = 2;         // Uses defaults for video (most strict).
-    GAIN_CORRECT_HDR = 3;           // Uses most relaxed settings to track
-                                    // across HDR frames, taken at different
-                                    // exposures.
-    GAIN_CORRECT_PHOTO_BURST = 4;   // More relaxed than video but stricter
-                                    // than HDR; use for photo burst where
-                                    // exposure between frames can change.
+    GAIN_CORRECT_MODE_DEFAULT_USER = 1;  // Uses default or user supplied bounds,
+                                         // i.e. gain_bias_bounds is left untouched.
+    GAIN_CORRECT_MODE_VIDEO = 2;         // Uses defaults for video (most strict).
+    GAIN_CORRECT_MODE_HDR = 3;           // Uses most relaxed settings to track
+                                         // across HDR frames, taken at different
+                                         // exposures.
+    GAIN_CORRECT_MODE_PHOTO_BURST = 4;   // More relaxed than video but stricter
+                                         // than HDR; use for photo burst where
+                                         // exposure between frames can change.
   }
 
   optional GainCorrectMode gain_correct_mode = 41
-      [default = GAIN_CORRECT_DEFAULT_USER];
+      [default = GAIN_CORRECT_MODE_DEFAULT_USER];
 
   // Bounds for the estimated model. If not set externally, will be set
   // based on GainCorrectMode.
@@ -550,25 +550,25 @@ message RegionFlowComputationOptions {
   // IMPORTANT: All the Retrieve* methods expect RGB when the descriptors
   // are computed.
   enum ImageFormat {
-    FORMAT_UNKNOWN = 0;
-    FORMAT_GRAYSCALE = 1;
-    FORMAT_RGB = 2;
-    FORMAT_RGBA = 3;
-    FORMAT_BGR = 4;
-    FORMAT_BGRA = 5;
+    IMAGE_FORMAT_UNKNOWN = 0;
+    IMAGE_FORMAT_GRAYSCALE = 1;
+    IMAGE_FORMAT_RGB = 2;
+    IMAGE_FORMAT_RGBA = 3;
+    IMAGE_FORMAT_BGR = 4;
+    IMAGE_FORMAT_BGRA = 5;
   }
 
   // Image format of the input.
-  optional ImageFormat image_format = 58 [default = FORMAT_RGB];
+  optional ImageFormat image_format = 58 [default = IMAGE_FORMAT_RGB];
 
   enum DescriptorExtractorType {
-    ORB =
+    DESCRIPTOR_EXTRACTOR_ORB =
         0;  // http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.370.4395&rep=rep1&type=pdf
   }
 
   // The descriptor extractor type used.
   optional DescriptorExtractorType descriptor_extractor_type = 65
-      [default = ORB];
+      [default = DESCRIPTOR_EXTRACTOR_ORB];
 
   // Whether to compute derivatives when building the pyramid. When set to
   // true, it's building a Laplacian pyramid. When set to false, it's building

--- a/mediapipe/util/tracking/region_flow_computation_test.cc
+++ b/mediapipe/util/tracking/region_flow_computation_test.cc
@@ -149,22 +149,22 @@ void RegionFlowComputationTest::MakeMovie(
   };
 
   switch (format) {
-    case RegionFlowComputationOptions::REGION_FLOW_FORMAT_RGB:
+    case RegionFlowComputationOptions::IMAGE_FORMAT_RGB:
       break;
 
-    case RegionFlowComputationOptions::REGION_FLOW_FORMAT_BGR:
+    case RegionFlowComputationOptions::IMAGE_FORMAT_BGR:
       convert(CV_8UC3, cv::COLOR_RGB2BGR);
       break;
 
-    case RegionFlowComputationOptions::REGION_FLOW_FORMAT_GRAYSCALE:
+    case RegionFlowComputationOptions::IMAGE_FORMAT_GRAYSCALE:
       convert(CV_8UC1, cv::COLOR_RGB2GRAY);
       break;
 
-    case RegionFlowComputationOptions::REGION_FLOW_FORMAT_RGBA:
+    case RegionFlowComputationOptions::IMAGE_FORMAT_RGBA:
       convert(CV_8UC4, cv::COLOR_RGB2RGBA);
       break;
 
-    case RegionFlowComputationOptions::REGION_FLOW_FORMAT_BGRA:
+    case RegionFlowComputationOptions::IMAGE_FORMAT_BGRA:
       convert(CV_8UC4, cv::COLOR_RGB2BGRA);
       break;
   }
@@ -241,15 +241,15 @@ TEST_P(RegionFlowComputationTest, FramePairTest) {
   EXPECT_NE(base_options_.tracking_options().output_flow_direction(),
             TrackingOptions::FLOW_DIRECTION_CONSECUTIVELY);
   // Test on grayscale input.
-  RunFramePairTest(RegionFlowComputationOptions::REGION_FLOW_FORMAT_GRAYSCALE);
+  RunFramePairTest(RegionFlowComputationOptions::IMAGE_FORMAT_GRAYSCALE);
   // Test on RGB input.
-  RunFramePairTest(RegionFlowComputationOptions::REGION_FLOW_FORMAT_RGB);
+  RunFramePairTest(RegionFlowComputationOptions::IMAGE_FORMAT_RGB);
   // Test on BGR input.
-  RunFramePairTest(RegionFlowComputationOptions::REGION_FLOW_FORMAT_BGR);
+  RunFramePairTest(RegionFlowComputationOptions::IMAGE_FORMAT_BGR);
   // Test on RGBA input.
-  RunFramePairTest(RegionFlowComputationOptions::REGION_FLOW_FORMAT_RGBA);
+  RunFramePairTest(RegionFlowComputationOptions::IMAGE_FORMAT_RGBA);
   // Test on BGRA input.
-  RunFramePairTest(RegionFlowComputationOptions::REGION_FLOW_FORMAT_BGRA);
+  RunFramePairTest(RegionFlowComputationOptions::IMAGE_FORMAT_BGRA);
 }
 
 TEST_P(RegionFlowComputationTest, ResolutionTests) {


### PR DESCRIPTION
1. remove extra CAMERA_MOTION_ prefix
2. Update Enum prefixes (TRACKING_POLICY, CORNER_EXTRACTION_METHOD, IRIS_INIT, DOWNSAMPLE_MODE,
DESCRIPTOR_EXTRACTOR, IMAGE_FORMAT, GAIN_CORRECT_MODE)
3. Add debug message for subgraph parser errors
