### PR TITLE
Tracker: Remove objects that are no longer detected

### DIFF
--- a/mediapipe/calculators/video/tracked_detection_manager_calculator.cc
+++ b/mediapipe/calculators/video/tracked_detection_manager_calculator.cc
@@ -34,7 +34,7 @@ namespace {
 
 using ::mediapipe::NormalizedRect;
 
-constexpr int kDetectionUpdateTimeOutMS = 5000;
+constexpr int kDetectionUpdateTimeOutMS = 1000;
 constexpr char kDetectionsTag[] = "DETECTIONS";
 constexpr char kDetectionBoxesTag[] = "DETECTION_BOXES";
 constexpr char kDetectionListTag[] = "DETECTION_LIST";
@@ -268,11 +268,6 @@ absl::Status TrackedDetectionManagerCalculator::Process(CalculatorContext* cc) {
 
     for (const auto& detection_ptr : all_detections) {
       const auto& detection = *detection_ptr.second;
-      // Only output detections that are synced.
-      if (detection.last_updated_timestamp() <
-          cc->InputTimestamp().Microseconds() / 1000) {
-        continue;
-      }
       output_detections->emplace_back(
           GetAxisAlignedDetectionFromTrackedDetection(detection));
       output_boxes->emplace_back(detection.bounding_box());

--- a/mediapipe/util/tracking/tracked_detection_manager.cc
+++ b/mediapipe/util/tracking/tracked_detection_manager.cc
@@ -93,7 +93,6 @@ std::vector<int> TrackedDetectionManager::UpdateDetectionLocation(
   }
   auto& detection = *detection_ptr->second;
   detection.set_bounding_box(bounding_box);
-  detection.set_last_updated_timestamp(timestamp);
 
   // It's required to do this here in addition to in AddDetection because during
   // fast motion, two or more detections of the same object could coexist since


### PR DESCRIPTION
Modify the Tracker calculator to drop objects that are no longer detected.

Made the following modifications:
1. Stop listening to tracked boxes to update the object timestamp. This means that any objects that don't receive a new detection will be deleted once the obsolete timeout is reached.
2. Decrease obsolete timeout from 5s to 1s.
3. Allow detections that haven't been updated w/ the current Input packet to be output. Necessary after we stop recording object timestamps from UpdateDetections in (1).
only update object timestamps based on the new detections.

Signed-off-by: Phillip Kuznetsov <philkuz@gimletlabs.ai>
